### PR TITLE
📦 Update Node version to 22.4.1 in Dockerfiles.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS dependencies
+FROM node:22.4.1-alpine AS dependencies
 
 WORKDIR /src
 
@@ -7,7 +7,7 @@ COPY .yarn/ ./.yarn/
 
 RUN yarn install --immutable
 
-FROM node:22-alpine AS builder
+FROM node:22.4.1-alpine AS builder
 
 WORKDIR /src
 
@@ -19,7 +19,7 @@ COPY --from=dependencies /src/node_modules ./node_modules/
 
 RUN yarn build
 
-FROM node:22-alpine AS runner
+FROM node:22.4.1-alpine AS runner
 
 RUN addgroup -S app \
     && adduser -S app -G app


### PR DESCRIPTION
Workaround: https://github.com/yarnpkg/berry/issues/6398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Node.js base image version in the Docker configuration for improved performance and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->